### PR TITLE
doc: Fix invalid GHA syntax in github-token example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ or
 
 ```yaml
 - uses: extractions/setup-just@v1
-  input:
+  with:
     github-token: ${{ secrets.MY_GITHUB_TOKEN }}
 ```
 


### PR DESCRIPTION
Thanks for this useful action. The new example for `github-token` produces a syntax error:

```
The workflow is not valid. [...]: Unexpected value 'input'
```

but it does work if you use `with` instead.