### PR TITLE
Update setup-crate to Node 24

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: extractions/setup-crate@4993624604c307fbca528d28a3c8b60fa5ecc859 # v1.4.0
+    - uses: extractions/setup-crate@579f05a3d77e6a26c3300aa8851537a1b801035a # node24
       with:
         repo: casey/just
         version: ${{ inputs.just-version }}


### PR DESCRIPTION
Updates the pinned setup-crate SHA to target Node 24, resolving the Node 20 deprecation warning.

Closes #26