### PR TITLE
feat: add just-version-file input to resolve version from a file

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,3 +39,29 @@ jobs:
     - name: Test
       run: |
         [ "$(just --justfile tests/Justfile)" = "Test..." ]
+
+  test-version-file:
+    needs: test-latest
+    strategy:
+      matrix:
+        include:
+          - file: .tool-versions
+            content: just 1.40.0
+            version: 1.40.0
+          - file: .just-version
+            content: 1.39.0
+            version: 1.39.0
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Create ${{ matrix.file }}
+      run: echo "${{ matrix.content }}" > "${{ matrix.file }}"
+    - name: Run self
+      uses: ./
+      with:
+        just-version-file: ${{ matrix.file }}
+    - name: Check version
+      run: just --version | grep -E "^just v?${{ matrix.version }}$"
+    - name: Test
+      run: |
+        [ "$(just --justfile tests/Justfile)" = "Test..." ]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ If you want a specific version of `just` you can specify this by passing the
     just-version: '1.46.0'
 ```
 
+Alternatively you can keep the version in a file and point the action at it with
+the `just-version-file` input. Both a `.tool-versions` file (the `just` entry is
+read) and a plain version file like `.just-version` are supported.
+
+```yaml
+- uses: extractions/setup-just@v4
+  with:
+    just-version-file: '.tool-versions'
+```
+
 To avoid rate-limiting, the default Github token (available to all actions) is
 automatically used to authenticate calls to Github. To override it, pass the
 input `github-token`.
@@ -36,10 +46,14 @@ input `github-token`.
 
 ### Inputs
 
-| Name           | Required | Description                                  | Type   | Default               |
-| -------------- | -------- | -------------------------------------------- | ------ | --------------------- |
-| `just-version` | no       | A valid NPM-style semver specification.      | string | *                     |
-| `github-token` | no       | A Github token to authenticate API requests. | string | `${{ github.token }}` |
+| Name                | Required | Description                                                   | Type   | Default               |
+| ------------------- | -------- | ------------------------------------------------------------- | ------ | --------------------- |
+| `just-version`      | no       | A valid NPM-style semver specification.                      | string | *                     |
+| `just-version-file` | no       | Path to a file (`.tool-versions` or plain) holding the version. | string | -                     |
+| `github-token`      | no       | A Github token to authenticate API requests.                 | string | `${{ github.token }}` |
+
+If both `just-version` and `just-version-file` are set, `just-version` takes
+precedence and the file is ignored.
 
 The semver specification is passed directly to NPM's [semver
 package](https://www.npmjs.com/package/semver). This GitHub Action will install

--- a/action.yaml
+++ b/action.yaml
@@ -7,6 +7,13 @@ branding:
 inputs:
   just-version:
     description: 'A valid semver specifier of the just version to install'
+  just-version-file:
+    description: >-
+      Path to a file that contains the just version to install, such as a
+      .tool-versions file (the `just <version>` entry is read) or a plain
+      file like .just-version (the first non-comment line is read). Ignored
+      when just-version is also set.
+    required: false
   github-token:
     description: 'Github token to use to authenticate downloads'
     required: false
@@ -14,8 +21,41 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Resolve just version from file
+      id: resolve
+      if: ${{ inputs.just-version-file != '' }}
+      shell: bash
+      env:
+        JUST_VERSION: ${{ inputs.just-version }}
+        JUST_VERSION_FILE: ${{ inputs.just-version-file }}
+      run: |
+        set -euo pipefail
+        if [ -n "$JUST_VERSION" ]; then
+          echo "::warning::both just-version and just-version-file were provided; using just-version and ignoring just-version-file"
+          exit 0
+        fi
+        if [ ! -f "$JUST_VERSION_FILE" ]; then
+          echo "::error::just-version-file '$JUST_VERSION_FILE' does not exist"
+          exit 1
+        fi
+        case "$(basename "$JUST_VERSION_FILE")" in
+          .tool-versions)
+            # asdf/mise format, e.g. `just 1.40.0` (extra fields and comments are ignored)
+            version="$(grep -E '^just[[:space:]]+' "$JUST_VERSION_FILE" | head -n1 | awk '{print $2}')"
+            ;;
+          *)
+            # Plain version file: first non-empty, non-comment line
+            version="$(grep -vE '^[[:space:]]*(#|$)' "$JUST_VERSION_FILE" | head -n1 | tr -d '[:space:]')"
+            ;;
+        esac
+        if [ -z "$version" ]; then
+          echo "::error::could not determine a just version from '$JUST_VERSION_FILE'"
+          exit 1
+        fi
+        echo "Resolved just version '$version' from '$JUST_VERSION_FILE'"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
     - uses: extractions/setup-crate@0551596312d4008a6dfbc4d3c38fa20eaef46d2d # v2.0.0
       with:
         repo: casey/just
-        version: ${{ inputs.just-version }}
+        version: ${{ inputs.just-version || steps.resolve.outputs.version }}
         github-token: ${{ inputs.github-token }}

--- a/action.yaml
+++ b/action.yaml
@@ -21,7 +21,6 @@ inputs:
 runs:
   using: composite
   steps:
-<<<<<<< HEAD
     - name: Resolve just version from file
       id: resolve
       if: ${{ inputs.just-version-file != '' }}


### PR DESCRIPTION
Adds a `just-version-file` input so the just version can be pinned in a file
(`.tool-versions` or a plain `.just-version`) instead of hardcoding it in the
workflow — mirroring the `*-version-file` inputs in `actions/setup-node`,
`actions/setup-go`, etc.

- `.tool-versions` → reads the `just <version>` entry (extra fields / comments ignored)
- plain file (e.g. `.just-version`) → reads the first non-comment, non-empty line
- if both `just-version` and `just-version-file` are set, `just-version` wins (with a warning)

Validation:
- New `test-version-file` CI job exercises both formats (`.tool-versions` → 1.40.0, `.just-version` → 1.39.0) and asserts the installed version
- Resolve logic verified locally: .tool-versions, plain file, both-set precedence, missing file, and missing `just` entry all behave correctly
- README updated with a usage example + inputs-table row